### PR TITLE
docs: add ClashX to Proxy Clients & GUI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ DNS proxy servers for privacy, ad-blocking, and encrypted DNS resolution (DoH, D
 
 Desktop and mobile apps for managing proxy connections across multiple protocols.
 
+- [ClashX-Pro/ClashX](https://github.com/ClashX-Pro/ClashX) — Native macOS proxy client built on Clash with menu bar UI, TUN mode, and Apple Silicon support.
 - [Dreamacro/clash](https://github.com/Dreamacro/clash) — Rule-based tunneling proxy in Go: VMess, VLESS, Shadowsocks, Trojan, SOCKS5, HTTP.
 - [MetaCubeX/mihomo](https://github.com/MetaCubeX/mihomo) — Enhanced Clash kernel with TUIC, Hysteria2, VLESS Reality, and advanced routing.
 - [hiddify/hiddify-app](https://github.com/hiddify/hiddify-app) — Multi-platform proxy client on sing-box supporting all major protocols.


### PR DESCRIPTION
## Summary

Add [ClashX](https://github.com/ClashX-Pro/ClashX) to the "Proxy Clients & GUI Tools" section.

ClashX is a native macOS proxy client built on the Clash core. It fills a gap in the current list — the section has cross-platform clients (Clash Verge, Hiddify, v2rayA) and Android clients (NekoBox), but no dedicated native macOS client.

**Key features:**
- Native macOS menu bar UI (follows Apple HIG)
- TUN (Enhanced) mode for system-level global proxy
- Apple Silicon (M1/M2/M3/M4) optimized
- Rule-based routing with Clash YAML config
- Free and open source (GPL-3.0)

## Changes

- Added ClashX entry to the "Proxy Clients & GUI Tools" section, placed before `Dreamacro/clash` since it's a client built on top of the Clash core.